### PR TITLE
Fix eusign data path case

### DIFF
--- a/frontend/src/Components/auth/EsignLogin.jsx
+++ b/frontend/src/Components/auth/EsignLogin.jsx
@@ -45,8 +45,8 @@ export default function EsignLogin({ onSuccess }) {
     if (mode === MODES.file) {
       (async () => {
         try {
-          // 7.1) Получаем JSON-файл: предполагаем, что он лежит по пути /public/eusign/Data/CAs.json
-          const resp = await fetch('/eusign/Data/CAs.json');
+          // 7.1) Получаем JSON-файл: предполагаем, что он лежит по пути /public/eusign/data/CAs.json
+          const resp = await fetch('/eusign/data/CAs.json');
           if (!resp.ok) throw new Error(`Ошибка ${resp.status} при загрузке CAs.json`);
 
           const json = await resp.json();

--- a/frontend/src/services/eusign.js
+++ b/frontend/src/services/eusign.js
@@ -30,7 +30,7 @@ class EUSignService {
       await this.#eu.SetXMLHTTPProxyService('/eu.proxy');
 
       // 2.2) CA-файлы
-      await this.#eu.SetCASettings('/eusign/Data/', '/eusign/Data/CACertificates.p7b');
+      await this.#eu.SetCASettings('/eusign/data/', '/eusign/data/CACertificates.p7b');
 
       // 2.3) (опционально) Локальное файловое хранилище для сертификатов
       await this.#eu.SetFileStoreSettings(true, '/eusign/FileStore/');


### PR DESCRIPTION
## Summary
- correct data directory case in EUSign service
- adjust EsignLogin fetch path

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6842abbc39c483238d323a6ac947d66a