### PR TITLE
Fix CA list loading for token login

### DIFF
--- a/frontend/src/Components/auth/EsignLogin.jsx
+++ b/frontend/src/Components/auth/EsignLogin.jsx
@@ -40,9 +40,9 @@ export default function EsignLogin({ onSuccess }) {
   const [getChallenge] = useEsignChallengeMutation();
   const [loginEsign] = useEsignLoginMutation();
 
-  // ========== Загрузка CA-списка при входе в режим FILE ==========
+  // ========== Загрузка CA-списка при входе в режим FILE или TOKEN ==========
   useEffect(() => {
-    if (mode === MODES.file) {
+    if (mode === MODES.file || mode === MODES.token) {
       (async () => {
         try {
           // 7.1) Получаем JSON-файл: предполагаем, что он лежит по пути /public/eusign/data/CAs.json


### PR DESCRIPTION
## Summary
- load CA dropdown options when file **or** token mode is selected

## Testing
- `npm --prefix frontend test --silent -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6842af9a2bd883238bff419108b723fb