### PR TITLE
Add token provider selection for EUSign

### DIFF
--- a/frontend/src/Components/auth/EsignLogin.jsx
+++ b/frontend/src/Components/auth/EsignLogin.jsx
@@ -28,6 +28,7 @@ export default function EsignLogin({ onSuccess }) {
 
   // --- 4) Данные для TOKEN ---
   const [tokenIndex, setTokenIndex] = useState(0);
+  const [tokenProviders, setTokenProviders] = useState([]);
 
   // --- 5) Данные для CLOUD ---
   const [cloudProviderId, setCloudProviderId] = useState('iit-cloud');
@@ -72,6 +73,19 @@ export default function EsignLogin({ onSuccess }) {
         } catch (err) {
           console.error('Не удалось загрузить список CA из CAs.json:', err);
           setCaList([]);
+        }
+      })();
+    }
+
+    if (mode === MODES.token) {
+      (async () => {
+        try {
+          const list = await eusign.listTokenProviders();
+          setTokenProviders(list);
+          if (list.length) setTokenIndex(list[0].index);
+        } catch (err) {
+          console.error('Не удалось получить список токенов:', err);
+          setTokenProviders([]);
         }
       })();
     }
@@ -226,6 +240,22 @@ export default function EsignLogin({ onSuccess }) {
           </option>
         ))}
       </select>
+
+      {/* Выбор токен-провайдера */}
+      <div style={{ marginBottom: 8 }}>
+        <label style={{ display: 'block', marginBottom: 4 }}>Token provider:</label>
+        <select
+          value={tokenIndex}
+          onChange={(e) => setTokenIndex(Number(e.target.value))}
+          style={{ width: '100%', padding: '6px' }}
+        >
+          {tokenProviders.map((tp) => (
+            <option key={tp.index} value={tp.index}>
+              {tp.name}
+            </option>
+          ))}
+        </select>
+      </div>
 
       <div style={{ marginBottom: 8 }}>
         <label style={{ display: 'block', marginBottom: 4 }}>Password:</label>

--- a/frontend/src/services/eusign.js
+++ b/frontend/src/services/eusign.js
@@ -71,6 +71,32 @@ class EUSignService {
     await this.#eu.ReadPrivateKey(password);
   }
 
+  /**
+   * Возвращает список доступных токен-провайдеров.
+   * Каждый элемент имеет форму { index: number, name: string }.
+   */
+  async listTokenProviders() {
+    await this.init();
+    try {
+      const count = await this.#eu.GetProtectedCMSProvidersCount();
+      const list = [];
+      for (let i = 0; i < count; i++) {
+        let name = `#${i}`;
+        try {
+          const info = await this.#eu.GetProtectedCMSProviderInfo(i);
+          if (info?.GetName) name = info.GetName();
+        } catch (e) {
+          // ignore errors when fetching provider info
+        }
+        list.push({ index: i, name });
+      }
+      return list;
+    } catch (err) {
+      console.error('Failed to get token providers:', err);
+      return [];
+    }
+  }
+
   // ======================================
   // 5) Методы для вкладки «CLOUD»
   // ======================================


### PR DESCRIPTION
## Summary
- allow choosing token provider in `EsignLogin`
- expose `listTokenProviders` helper in eusign service

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b415b1308323b8759d9e260b4fa1