### PR TITLE
Fix EUSign login issues and extend provider lists

### DIFF
--- a/frontend/public/eusign/data/Clouds.json
+++ b/frontend/public/eusign/data/Clouds.json
@@ -1,0 +1,4 @@
+[
+  { "id": "iit-cloud", "name": "ІІТ – хмарний підпис (2)" },
+  { "id": "acsk-id-gov", "name": "ID.GOV.UA" }
+]

--- a/frontend/src/app/mainApi.js
+++ b/frontend/src/app/mainApi.js
@@ -17,17 +17,21 @@ export const baseQuery = fetchBaseQuery({
 export const checkRefreshQuery = async (args, api, extraOptions) => {
   await refreshToken();
   return baseQuery(args, api, extraOptions);
-}
+};
 
 export const mainApi = createApi({
   reducerPath: 'mainApi',
   baseQuery: checkRefreshQuery,
   endpoints: (build) => ({
     esignChallenge: build.mutation({
-      query: () => ({ url: '/ms-users/api/v1/token/esign/challenge/', method: 'POST' }),
+      query: () => ({ url: '/ms-users/api/v1/token/esign/challenge/', method: 'POST' })
     }),
     esignLogin: build.mutation({
-      query: (body) => ({ url: '/ms-users/api/v1/token/esign/confirm/', method: 'POST', body }),
+      query: ({ state, ...body }) => ({
+        url: `/ms-users/api/v1/token/esign/confirm/?state=${encodeURIComponent(state)}`,
+        method: 'POST',
+        body
+      })
     }),
     publicCompaniesList: build.query({
       query: (params) => ({
@@ -106,5 +110,5 @@ export const {
   useReferenceBookKeyQuery,
   useLazyMsFilesDownloadQuery,
   useReferenceBookCompactQuery,
-  useUpdateLanguageMutation,
+  useUpdateLanguageMutation
 } = mainApi;


### PR DESCRIPTION
## Summary
- pass state parameter as query string when confirming EUSign login
- load available token providers with fallback message
- support cloud provider list from `Clouds.json`
- add default cloud provider data

## Testing
- `npm run format` *(passes)*
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6842aa9377008323b5aad6cc0fdcf297