### PR TITLE
Fix EUSign challenge request

### DIFF
--- a/frontend/src/app/mainApi.js
+++ b/frontend/src/app/mainApi.js
@@ -24,7 +24,10 @@ export const mainApi = createApi({
   baseQuery: checkRefreshQuery,
   endpoints: (build) => ({
     esignChallenge: build.mutation({
-      query: () => ({ url: '/ms-users/api/v1/token/esign/challenge/', method: 'POST' })
+      query: ({ state }) => ({
+        url: `/ms-users/api/v1/token/esign/challenge/?state=${encodeURIComponent(state)}`,
+        method: 'POST'
+      })
     }),
     esignLogin: build.mutation({
       query: ({ state, ...body }) => ({


### PR DESCRIPTION
## Summary
- add `state` parameter to esign challenge request
- include generated state in login logic

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm run format` *(fails: out of memory)*
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bc485910832386608fe353f4a12c